### PR TITLE
fix(sourcemaps): reduce verbose noise

### DIFF
--- a/src/index.mts
+++ b/src/index.mts
@@ -167,8 +167,8 @@ export function maybeRewriteSourcemapWithReactProd(
   const remapped = remapping(inputSourcemap as SourceMapInput, (file, ctx) => {
     const matchedPackage = SUPPORTED_PACKAGES.exec(ctx.source);
     if (matchedPackage === null) {
-      if (options.verbose) {
-        log(`Skipping sourcemap ${file} because it does not contain a sourcemap for remapping`);
+      if (options.verbose && ctx.source.endsWith(".js.map")) {
+        log(`Skipping sourcemap ${file} because it does not contain a source for remapping`);
       }
       return null;
     }


### PR DESCRIPTION
verbose mode logging generates a lot of noise for non sourcemaps files, this PR changes so we outputs logs only when true .js.map sourcemaps are skipped

<img width="1533" alt="CleanShot 2023-09-27 at 15 06 12@2x" src="https://github.com/markerikson/react-prod-sourcemaps/assets/9317857/367faca1-41c8-41dd-ae6b-e2e28cabbbf9">
